### PR TITLE
Enable listening on IPv4 only

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -13,7 +13,7 @@ port =
   |> String.to_integer()
 
 config :relayman, RelaymanWeb.Endpoint,
-  http: [:inet6, port: port],
+  http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}, port: port],
   secret_key_base: secret_key_base
 
 config :relayman, RelaymanWeb.Endpoint,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -13,7 +13,7 @@ port =
   |> String.to_integer()
 
 config :relayman, RelaymanWeb.Endpoint,
-  http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}, port: port],
+  http: [ip: {0, 0, 0, 0}, port: port],
   secret_key_base: secret_key_base
 
 config :relayman, RelaymanWeb.Endpoint,


### PR DESCRIPTION
IPv6 is disabled on harden AMI
This PR is to force relayman to listen on IPv4 only